### PR TITLE
Makefile: Disable PIE option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 program: program.c
-	cc -rdynamic -g -o program program.c
+	cc -no-pie -rdynamic -g -o program program.c
 
 run: program
 	./program | ./srcline.py


### PR DESCRIPTION
Since Ubuntu 16.10, gcc generates position independent executable (PIE)
by default. This messes up a map between addresses of a program and a
process. This commit is backward-compatible because PIE is turned off
by default in older versions and they work well.

Signed-off-by: Yunjae Lee <lyj7694@gmail.com>